### PR TITLE
Update environment configuration and README for Django frontend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Copy the environment variables file:
 cp docker/default.env .env
 ```
 
-Edit the values in `.env` (e.g., SECRET_KEY, DATABASE_USER, DATABASE_PASS, DATABASE_DB).
+Edit the values in `.env` (e.g., SECRET_KEY, DATABASE_USER, DATABASE_PASS, DATABASE_DB, ENABLE_DJANGO_FRONTEND, STATIC_ROOT).
 
 #### 2.2. Start the containers
 ```bash
@@ -93,6 +93,8 @@ DATABASE_HOST: "localhost"
 DATABASE_USER: "your_db_user"
 DATABASE_PASS: "your_db_password"
 DATABASE_DB: "your_db_name"
+ENABLE_DJANGO_FRONTEND: 1  # 1 - enable front, 0 - disable
+STATIC_ROOT: "/app/static" # Absolute path for static files (optional)
 ```
 
 #### 4.3. Apply migrations and run

--- a/docker/default.env
+++ b/docker/default.env
@@ -9,3 +9,9 @@ DATABASE_USER=
 DATABASE_PASS=
 DATABASE_DB=
 DATABASE_MOUNTED_DUMPS_DIR=
+
+# Enable or disable Django frontend (front)
+ENABLE_DJANGO_FRONTEND=1
+
+# Absolute path for static files (if not set, defaults to /app/static)
+STATIC_ROOT=

--- a/docker_debug/default.env
+++ b/docker_debug/default.env
@@ -9,3 +9,9 @@ DATABASE_USER=
 DATABASE_PASS=
 DATABASE_DB=
 DATABASE_MOUNTED_DUMPS_DIR=
+
+# Enable or disable Django frontend (front)
+ENABLE_DJANGO_FRONTEND=1
+
+# Absolute path for static files (if not set, defaults to /app/static)
+STATIC_ROOT=

--- a/private_library/settings.py
+++ b/private_library/settings.py
@@ -52,8 +52,10 @@ INSTALLED_APPS = [
     'django_bootstrap5',
     'private_library',
     'core',
-    'front',
 ]
+
+if config.get('ENABLE_DJANGO_FRONTEND', True) is True:
+    INSTALLED_APPS.append('front')
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
- Added ENABLE_DJANGO_FRONTEND and STATIC_ROOT variables to docker/default.env and docker_debug/default.env.
- Updated README.md to reflect new environment variables and their usage.
- Conditionally include 'front' app in INSTALLED_APPS based on ENABLE_DJANGO_FRONTEND setting in settings.py.